### PR TITLE
fix: Deployment error and update timeouts

### DIFF
--- a/parma_mining/peopledatalabs/analytics_client.py
+++ b/parma_mining/peopledatalabs/analytics_client.py
@@ -28,7 +28,7 @@ class AnalyticsClient:
             "Authorization": f"Bearer {token}",
         }
 
-        response = httpx.post(api_endpoint, json=data, headers=headers)
+        response = httpx.post(api_endpoint, json=data, headers=headers, timeout=120)
 
         if response.status_code in [200, 201]:
             return response.json()

--- a/parma_mining/peopledatalabs/client.py
+++ b/parma_mining/peopledatalabs/client.py
@@ -29,7 +29,9 @@ class PdlClient:
             "x-api-key": self.api_key,
         }
         full_path = urljoin(self.base_url, self.api_version + path)
-        return httpx.request("GET", url=full_path, headers=headers, params=query)
+        return httpx.request(
+            "GET", url=full_path, headers=headers, params=query, timeout=30
+        )
 
     def get_organization_details(
         self, org_identifier: str, identifier_type: str

--- a/terraform/module/main.tf
+++ b/terraform/module/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/module/service.tf
+++ b/terraform/module/service.tf
@@ -32,6 +32,15 @@ resource "google_cloud_run_service" "parma_mining_peopledatalabs_cloud_run" {
     spec {
       containers {
         image = data.local_file.image_name.content
+
+        resources {
+          limits = {
+            # 0.5 vCPU, 256 MB RAM for ${var.env} == staging, else 1 vCPU, 512 MB RAM
+            cpu    = var.env == "staging" ? "1" : "1"
+            memory = var.env == "staging" ? "256Mi" : "512Mi"
+          }
+        }
+
         ports {
           container_port = 8080
         }
@@ -61,6 +70,13 @@ resource "google_cloud_run_service" "parma_mining_peopledatalabs_cloud_run" {
         }
       }
     }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "10"
+      }
+    }
+
   }
 
   traffic {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.6"
+      version = "5.12.0"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
# Motivation

GCP made some API adjustments invalidating the defaults in our used terraform providers.

httpx’s default timeout of 5 seconds is updated.