### PR TITLE
fix: Discovery response data_type name

### DIFF
--- a/parma_mining/peopledatalabs/api/main.py
+++ b/parma_mining/peopledatalabs/api/main.py
@@ -144,7 +144,7 @@ def search_organizations(
         )
         # Return same name only to agree with the common interface among data sources
         # There is no discover for PDL
-        response = DiscoveryResponse(handles=[company.name])
+        response = DiscoveryResponse(name=[company.name])
         response_data[company.company_id] = response
 
     current_date = datetime.now()

--- a/parma_mining/peopledatalabs/model.py
+++ b/parma_mining/peopledatalabs/model.py
@@ -101,7 +101,7 @@ class DiscoveryRequest(BaseModel):
 class DiscoveryResponse(BaseModel):
     """Define the output model for the discovery endpoint."""
 
-    handles: list[str] = []
+    name: list[str] = []
 
 
 class FinalDiscoveryResponse(BaseModel):


### PR DESCRIPTION
# Motivation

Discovery was giving wrong `data_type`, it needs to be `name` instead of `handles`

# Changes

- Discovery response key name changed.

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] my functions are fully typed
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
